### PR TITLE
Updates to run on web

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,0 +1,14 @@
+Изменения для сборки в WebAssembly:
+
+- `clean_cmake.py` - скрипт, очищающий кэш Cmake;
+- `empp_throwback.py` - скрипт, очищающий лишние параметры и запускающий em++;
+- `extrct_headers.py` - скрипт, собирающий все хедеры в отдельную папку.
+
+Также были внесены изменения в CMakeLists.txt, позволяющие установить параметры сборки с помощью флагов запуска Cmake. Временно закомментирована строка в *WilsonCloudChamber.cpp*, поскольку ее наличие вызывает ошибку исполнения при запуске в вебе.
+
+Инструкция по сборке (MacOS):
+
+1. Установить Emscripten: `brew install emscripten`
+2. Запустить Cmake: `cmake -DPLATFORM_WEB=1 -DCMAKE_CXX_COMPILER=$(pwd)/empp_throwback.py -DCMAKE_CXX_COMPILER_WORKS=1 .`
+3. Запустить Make: `make`
+4. Сохранить результат сборки по пути *phycoub/libphycoub.a*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,14 @@ project(PhyCoubAll)
 
 include(PlatformConfig.cmake)
 
-enable_testing()
+if (DEFINED PLATFORM_WEB)
+    set(CMAKE_AR "emar")
+    set(CMAKE_STATIC_LIBRARY_SUFFIX ".a")
+    set(CMAKE_CXX_CREATE_STATIC_LIBRARY "<CMAKE_AR> rc <TARGET> <OBJECTS>")
+else()
+    enable_testing()
+endif()
+
 add_subdirectory(phycoub)
 
 if(DEFINED QT_PATH)

--- a/clean_cmake.py
+++ b/clean_cmake.py
@@ -1,0 +1,13 @@
+import os, shutil
+
+def clean_folder(current_folder: str):
+    try:
+        shutil.rmtree(os.path.join(current_folder, 'CMakeFiles'))
+    except:
+        pass
+    for folder in os.listdir(current_folder):
+        if os.path.isdir(os.path.join(current_folder, folder)):
+            clean_folder(os.path.join(current_folder, folder))
+
+home_folder = os.path.dirname(os.path.abspath(__file__))
+clean_folder(home_folder)

--- a/empp_throwback.py
+++ b/empp_throwback.py
@@ -1,0 +1,8 @@
+#!/usr/bin/python3
+import subprocess, sys
+
+argv = []
+for arg in sys.argv[1:]:
+    if arg not in ['-arch', 'arm64']:
+        argv.append(arg)
+exit(subprocess.call(['em++', *argv]))

--- a/extract_headers.py
+++ b/extract_headers.py
@@ -1,0 +1,19 @@
+import os, shutil
+
+home_folder = os.path.dirname(os.path.abspath(__file__))
+headers_folder = os.path.join(home_folder, 'headers')
+
+def extract_folder(current_folder: str):
+    if current_folder.split('/')[-1] in ['headers', 'gtest', 'eigen', 'tests', 'benchmark']:
+        return
+
+    for current_file in os.listdir(current_folder):
+        if os.path.isdir(os.path.join(current_folder, current_file)):
+            extract_folder(os.path.join(current_folder, current_file))
+        elif current_file.endswith('.h'):
+            shutil.copy(os.path.join(current_folder, current_file), os.path.join(headers_folder, current_file))
+
+if os.path.exists(headers_folder):
+    shutil.rmtree(headers_folder)
+os.mkdir(headers_folder)
+extract_folder(home_folder)

--- a/phycoub/CMakeLists.txt
+++ b/phycoub/CMakeLists.txt
@@ -80,4 +80,6 @@ add_library(phycoub STATIC
 add_custom_command(TARGET phycoub
         POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:phycoub> .)
 
-include(Tests.cmake)
+if (NOT DEFINED PLATFORM_WEB)
+	include(Tests.cmake)
+endif()

--- a/phycoub/examples/WilsonCloudChamber.cpp
+++ b/phycoub/examples/WilsonCloudChamber.cpp
@@ -16,7 +16,8 @@ WilsonCloudChamber::WilsonCloudChamber()
     initCalculationGroup();
     initElectricField();
     initMagneticField();
-    initInterCommunication();
+    // Uncomment the line above to make this working outside web
+    // initInterCommunication();
     initSourcesAndLifeTimeControllers();
     initWithParticleGroups();
 


### PR DESCRIPTION
Изменения для сборки в WebAssembly:

- `clean_cmake.py` - скрипт, очищающий кэш Cmake;
- `empp_throwback.py` - скрипт, очищающий лишние параметры и запускающий em++;
- `extrct_headers.py` - скрипт, собирающий все хедеры в отдельную папку.

Также были внесены изменения в CMakeLists.txt, позволяющие установить параметры сборки с помощью флагов запуска Cmake. Временно закомментирована строка в *WilsonCloudChamber.cpp*, поскольку ее наличие вызывает ошибку исполнения при запуске в вебе.

Инструкция по сборке (MacOS):

1. Установить Emscripten: `brew install emscripten`
2. Запустить Cmake: `cmake -DPLATFORM_WEB=1 -DCMAKE_CXX_COMPILER=$(pwd)/empp_throwback.py -DCMAKE_CXX_COMPILER_WORKS=1 .`
3. Запустить Make: `make`
4. Сохранить результат сборки по пути *phycoub/libphycoub.a*